### PR TITLE
Migrate from failure to anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "ISC"
 
 [dependencies]
 anyhow = "1.0"
-failure = "0.1"
 futures-util = "0.3.1"
 hex = "0.4"
 hyper = { version = "0.13", features = ["stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/akshayknarayan/hyper-unix-connector"
 license = "ISC"
 
 [dependencies]
+anyhow = "1.0"
 failure = "0.1"
 futures-util = "0.3.1"
 hex = "0.4"


### PR DESCRIPTION
failure is deprecated: https://github.com/rust-lang-nursery/failure/pull/347

It is replaced in this PR with a non-deprecated library, anyhow.