### PR TITLE
Remove not required features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ license = "ISC"
 
 [dependencies]
 anyhow = "1.0"
-futures-util = "0.3"
 hex = "0.4"
 hyper = { version = "0.14", features = ["client", "server", "http1"] }
 tokio = { version = "1.0", features = ["net"] }
 pin-project = "1.0"
 
 [dev-dependencies]
+futures-util = "0.3"
 hyper = { version = "0.14", features = ["stream"] }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ license = "ISC"
 anyhow = "1.0"
 hex = "0.4"
 hyper = { version = "0.14", features = ["client", "server", "http1"] }
-tokio = { version = "1.0", features = ["net"] }
 pin-project = "1.0"
+tokio = { version = "1.0", features = ["net"] }
 
 [dev-dependencies]
 futures-util = "0.3"
-hyper = { version = "0.14", features = ["stream"] }
+hyper = { version = "0.14", features = ["runtime", "stream"] }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ license = "ISC"
 anyhow = "1.0"
 futures-util = "0.3"
 hex = "0.4"
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14", features = ["client", "server", "http1"] }
 tokio = { version = "1.0", features = ["net"] }
 pin-project = "1.0"
 
 [dev-dependencies]
+hyper = { version = "0.14", features = ["stream"] }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ anyhow = "1.0"
 futures-util = "0.3"
 hex = "0.4"
 hyper = { version = "0.14", features = ["full"] }
-tokio = { version = "1.0", features = ["net", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["net"] }
 pin-project = "1.0"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ impl hyper::server::accept::Accept for UnixConnector {
             .poll_accept(cx)
             .map_ok(|(stream, _addr)| stream)
             .map_err(|e| e.into())
-            .map(|f| Some(f))
+            .map(Some)
     }
 }
 


### PR DESCRIPTION
We do not actually require `http1` feature for `hyper` but need access to `Accept` and `Connection` traits.. (which can be available only on `http1` / `http2` features).